### PR TITLE
Rework of the logistic controller and introdution of a PID controller

### DIFF
--- a/pwm-fan.sh
+++ b/pwm-fan.sh
@@ -37,8 +37,8 @@ LOGISTIC_b=10
 #PID_THERMAL_IDEAL=45
 # https://en.wikipedia.org/wiki/PID_controller#Loop_tuning
 PID_Kp=$((DEFAULT_PERIOD/100))
-PID_Ki=$((DEFAULT_PERIOD/500))
-PID_Kd=$((DEFAULT_PERIOD/300))
+PID_Ki=$((DEFAULT_PERIOD/1000))
+PID_Kd=$((DEFAULT_PERIOD/50))
 # path to the pwm dir in the sysfs interface
 PWMCHIP_ROOT='/sys/class/pwm/'
 # path to the thermal dir in the sysfs interface

--- a/pwm-fan.sh
+++ b/pwm-fan.sh
@@ -501,7 +501,7 @@ while getopts 'c:C:d:D:fF:hl:m:o:p:s:t:T:u:U:' OPT; do
       THERMAL_CONTROLLER="$OPTARG"
       if [[ ! "$THERMAL_CONTROLLER" =~ ^(logistic|pid)$ ]]; then
         message "The value for the '-o' argument ($THERMAL_CONTROLLER) is invalid." 'ERROR'
-        message "The thermal controller must be either \'logistic\' or \'pid\'." 'ERROR'
+        message "The thermal controller must be either 'logistic' or 'pid'." 'ERROR'
         exit 1
       fi
       ;;

--- a/pwm-fan.sh
+++ b/pwm-fan.sh
@@ -33,12 +33,12 @@ LOGISTIC_TEMP_CRITICAL=75
 LOGISTIC_a=1
 LOGISTIC_b=10
 # uncomment and edit PID_THERMAL_IDEAL to set a fixed IDEAL temperature for the PID controller;
-# otherwise, the initial temperature after startup is used as reference.
+# otherwise, the initial temperature after startup (+2°C) is used as reference.
 #PID_THERMAL_IDEAL=45
 # https://en.wikipedia.org/wiki/PID_controller#Loop_tuning
-PID_Kp=$((DEFAULT_PERIOD/200))
-PID_Ki=$((DEFAULT_PERIOD/3000))
-PID_Kd=$((DEFAULT_PERIOD/600))
+PID_Kp=$((DEFAULT_PERIOD/100))
+PID_Ki=$((DEFAULT_PERIOD/500))
+PID_Kd=$((DEFAULT_PERIOD/300))
 # path to the pwm dir in the sysfs interface
 PWMCHIP_ROOT='/sys/class/pwm/'
 # path to the thermal dir in the sysfs interface
@@ -283,7 +283,7 @@ function_pid () {
 controller_pid () {
   # i_error cannot be local to be cumulative since it was first declared.
   local p_error d_error model duty_cycle
-  p_error="$((${TEMPS[-1]}-${PID_THERMAL_IDEAL:-$((THERMAL_INITIAL))}))"
+  p_error="$((${TEMPS[-1]}-${PID_THERMAL_IDEAL:-$((THERMAL_INITIAL+2))}))"
   i_error="$((${i_error:-0}+p_error))"
   d_error="$((${TEMPS[-1]}-${TEMPS[-2]}))"
   # TODO: Kp, Ki, and Kd could be auto tunned here; currently, they are not declared and PID_ vars are used.


### PR DESCRIPTION
The main purpose of this PR is **to add a simple PID controller** for the fan duty cycle based on the monitored thermal device.  There is a lot of room to improved such a controller (e.g., addition of anti-windup) but the current version has been quite stable during my preliminary tests and I'm happy enough with it.  The idea is to simply add an alternative to the (default) logistic controller.

(Of note, after playing around with a few auto-tuning alternatives, for now, I've decided to not add any of them because they require an algorithm to artificially increase the temperature of the monitored device.  This becomes complicated when the monitored device is not the cpu/soc, and even then, the idea of introducing high load (or waiting for low load) for a simple fan script does not sound like a good idea to me, even if just for a few minutes.  My current understanding is that if someone wants to use the PID controller with non-default values, then they know what they are doing and will be able to manually tune its parameters.)

In addition, the PR includes the following changes:

- The logic of all controllers was modified to allow a clean implementation of the two existing ones and any future controllers.

- Introduction of a new argument (`-o`) that lets users choose a thermal controller they want to use ('logistic' or 'pid').

- Key controller parameters were added to the top of the script along with other global variables. This makes it easier to edit them without going too much into the specifics of their implementation.
  - Please note that the default values of `Kp`, `Ki` and `Kd` have not been tuned yet.  Current values are just estimates of what I think should be a reasonable rate of change in nanoseconds of the duty cycle per unit change in Celsius for each PID component, with the proportional part driving the main changes.  The gist of each parameter is that `Kp` has to do with the *present* changes in temperature, `Ki` with the *past*, since it accumulates over the entire run, and `Kd` with the possible *future* values.

- Increased the default fan startup time to gather a more reliable metric of the initial temperature to be used by the PID controller as the ideal/desired one.

- FIxed a typo in the warning message about `CACHE_ROOT`.

I will probably merge this into `master` next week, unless someone else chimes in with suggested changes.

---

@araynard, please feel free to test and review this implementation if you have the time.  this is the one that introduces the PID controller I mentioned before.